### PR TITLE
[fix] defend code for region lock game

### DIFF
--- a/dags/game/game_ccu_to_s3.py
+++ b/dags/game/game_ccu_to_s3.py
@@ -53,6 +53,7 @@ def get_ccu():
                     break
             else:
                 print(f"Failed to get CCU of {game}!")
+                temp = {"player_count": 0, "result": 0, "game_id": appid}
         else:
             temp["game_id"] = appid
             data.append(temp)  # API 응답을 리스트에 추가

--- a/dags/game/game_price_to_s3.py
+++ b/dags/game/game_price_to_s3.py
@@ -63,14 +63,18 @@ def get_price():
             else:
                 print(f"Failed to get price of {appid, name}!")
 
-        if not temp:
+        if not temp or not temp[appid]["success"]:
             temp = {
-                appid: {
-                    "success": False,
-                    "data": {
-                        "price_overview": {"final": 999999999, "initial": 999999999}
+                "success": False,
+                "data": {
+                    "steam_appid": appid,
+                    "price_overview": {
+                        "final": 999999999,
+                        "initial": 999999999,
+                        "discount_percent": 0,
+                        "final_formatted": "₩ 999,999,999",
                     },
-                }
+                },
             }
         else:
             temp = temp[appid]


### PR DESCRIPTION
<!-- 제목 : [#{issue number}] {이슈 제목}-->
### 작업 분류

- [x] 신규 기능
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!--  작업한 내용을 적어주세요. -->
Steam이 특정 게임을 한국에서 더 이상 팔지 않는 이른바 지역락(Region Lock)이 발생하는 경우의 
방어 코드를 Json raw DAG에 추가했습니다.

script에서 별다른 수정이 필요없도록 작성했습니다.

### 생각해볼 문제
<!-- 생략 가능 -->

resolve #{issue number}